### PR TITLE
Fix a few crashes I had

### DIFF
--- a/ff_meters_LevelMeterSource.h
+++ b/ff_meters_LevelMeterSource.h
@@ -277,7 +277,10 @@ public:
      */
     float getMaxLevel (const int channel) const
     {
-        return levels.at (channel).max;
+		if (channel < levels.size())
+			return levels.at(channel).max;
+		else
+			return 0.0f;
     }
 
     /**
@@ -286,7 +289,10 @@ public:
      */
     float getMaxOverallLevel (const int channel) const
     {
-        return levels.at (channel).maxOverall;
+		if (channel < levels.size())
+			return levels.at(channel).maxOverall;
+		else
+			return 0.0f;
     }
 
     /**
@@ -295,7 +301,10 @@ public:
      */
     float getRMSLevel (const int channel) const
     {
-        return levels.at (channel).getAvgRMS();
+		if (channel < levels.size())
+			return levels.at(channel).getAvgRMS();
+		else
+			return 1.0f;
     }
 
     /**
@@ -303,7 +312,12 @@ public:
      */
     bool getClipFlag (const int channel) const
     {
-        return levels.at (channel).clip;
+		if (channel < levels.size()) {
+			return levels.at(channel).clip;
+		}
+		else {
+			return false;
+		}
     }
 
     /**


### PR DESCRIPTION
 I might be using the component the wrong way, but I am able to trigger these functions being called with a channel ID that no longer is within the valid channel range, and this will crash the application within the at() operation.

I think this happens when the draw loop/audio loop is running, and some reconfiguration takes place? I wasn't really able to reproduce the crash yet.
