### PR TITLE
Fix clang warnings

### DIFF
--- a/ff_meters_LevelMeter.cpp
+++ b/ff_meters_LevelMeter.cpp
@@ -41,14 +41,14 @@
 FFAU::LevelMeter::LevelMeter (const MeterFlags type)
   : meterType       (type)
 {
-    onMaxLevelClicked = [](FFAU::LevelMeter& meter, int channel, juce::ModifierKeys mods)
+    onMaxLevelClicked = [](FFAU::LevelMeter& meter, [[maybe_unused]] int channel, [[maybe_unused]] juce::ModifierKeys mods)
     {
         // default clear all indicators. Overwrite this lambda to change the behaviour
         meter.clearMaxLevelDisplay();
         meter.clearClipIndicator();
     };
 
-    onClipLightClicked = [](FFAU::LevelMeter& meter, int channel, juce::ModifierKeys mods)
+    onClipLightClicked = [](FFAU::LevelMeter& meter, [[maybe_unused]] int channel, [[maybe_unused]] juce::ModifierKeys mods)
     {
         // default clear all indicators. Overwrite this lambda to change the behaviour
         meter.clearMaxLevelDisplay();

--- a/ff_meters_LevelMeter.h
+++ b/ff_meters_LevelMeter.h
@@ -224,7 +224,7 @@ public:
     };
 
     LevelMeter (const MeterFlags type = HasBorder);
-    ~LevelMeter ();
+    ~LevelMeter () override;
 
     /**
      Allows to change the meter's configuration by setting a combination of MeterFlags

--- a/ff_meters_LevelMeterSource.h
+++ b/ff_meters_LevelMeterSource.h
@@ -65,7 +65,7 @@ private:
         clip (false),
         reduction (1.0f),
         hold (0),
-        rmsHistory (rmsWindow, 0.0),
+        rmsHistory ((size_t) rmsWindow, 0.0),
         rmsSum (0.0),
         rmsPtr (0)
         {}
@@ -104,7 +104,7 @@ private:
             if (rmsHistory.size() > 0)
                 return std::sqrt (std::accumulate (rmsHistory.begin(), rmsHistory.end(), 0.0f) / rmsHistory.size());
 
-            return std::sqrt (rmsSum);
+            return (float) std::sqrt (rmsSum);
         }
 
         void setLevels (const juce::int64 time, const float newMax, const float newRms, const juce::int64 _holdMSecs)
@@ -127,7 +127,7 @@ private:
 
         void setRMSsize (const int numBlocks)
         {
-            rmsHistory.assign (numBlocks, 0.0f);
+            rmsHistory.assign ((size_t) numBlocks, 0.0f);
             rmsSum  = 0.0;
             if (numBlocks > 1)
                 rmsPtr %= rmsHistory.size();
@@ -140,8 +140,8 @@ private:
             const double squaredRMS = std::min (newRMS * newRMS, 1.0f);
             if (rmsHistory.size() > 0)
             {
-                rmsHistory [rmsPtr] = squaredRMS;
-                rmsPtr = (rmsPtr + 1) % rmsHistory.size();
+                rmsHistory [(size_t) rmsPtr] = squaredRMS;
+                rmsPtr = (rmsPtr + 1) % (int) rmsHistory.size();
             }
             else
             {
@@ -179,7 +179,7 @@ public:
      */
     void resize (const int channels, const int rmsWindow)
     {
-        levels.resize (channels, ChannelData (rmsWindow));
+        levels.resize ((size_t) channels, ChannelData (rmsWindow));
         for (ChannelData& l : levels) {
             l.setRMSsize (rmsWindow);
         }
@@ -201,11 +201,11 @@ public:
 
 #if FF_AUDIO_ALLOW_ALLOCATIONS_IN_MEASURE_BLOCK
 #warning The use of levels.resize() is not realtime safe. Please call resize from the message thread and set this config setting to 0 via Projucer.
-            levels.resize (numChannels);
+            levels.resize ((size_t) numChannels);
 #endif
 
             for (int channel=0; channel < std::min (numChannels, int (levels.size())); ++channel) {
-                levels [channel].setLevels (lastMeasurement,
+                levels [(size_t) channel].setLevels (lastMeasurement,
                                             buffer.getMagnitude (channel, 0, numSamples),
                                             buffer.getRMSLevel  (channel, 0, numSamples),
                                             holdMSecs);
@@ -244,7 +244,7 @@ public:
     void setReductionLevel (const int channel, const float reduction)
     {
         if (juce::isPositiveAndBelow (channel, static_cast<int> (levels.size ())))
-            levels [channel].reduction = reduction;
+            levels [(size_t) channel].reduction = reduction;
     }
 
     /**
@@ -274,7 +274,7 @@ public:
     float getReductionLevel (const int channel) const
     {
         if (juce::isPositiveAndBelow (channel, static_cast<int> (levels.size ())))
-            return levels [channel].reduction;
+            return levels [(size_t) channel].reduction;
 
         return -1.0f;
     }
@@ -285,7 +285,7 @@ public:
      */
     float getMaxLevel (const int channel) const
     {
-        return levels.at (channel).max;
+        return levels.at ((size_t) channel).max;
     }
 
     /**
@@ -294,7 +294,7 @@ public:
      */
     float getMaxOverallLevel (const int channel) const
     {
-        return levels.at (channel).maxOverall;
+        return levels.at ((size_t) channel).maxOverall;
     }
 
     /**
@@ -303,7 +303,7 @@ public:
      */
     float getRMSLevel (const int channel) const
     {
-        return levels.at (channel).getAvgRMS();
+        return levels.at ((size_t) channel).getAvgRMS();
     }
 
     /**
@@ -311,7 +311,7 @@ public:
      */
     bool getClipFlag (const int channel) const
     {
-        return levels.at (channel).clip;
+        return levels.at ((size_t) channel).clip;
     }
 
     /**
@@ -319,7 +319,7 @@ public:
      */
     void clearClipFlag (const int channel)
     {
-        levels.at (channel).clip = false;
+        levels.at ((size_t) channel).clip = false;
     }
 
     void clearAllClipFlags ()
@@ -334,7 +334,7 @@ public:
      */
     void clearMaxNum (const int channel)
     {
-        levels.at (channel).maxOverall = -80.0f;
+        levels.at ((size_t) channel).maxOverall = -80.0f;
     }
 
     /**

--- a/ff_meters_LevelMeterSource.h
+++ b/ff_meters_LevelMeterSource.h
@@ -102,12 +102,12 @@ private:
         float getAvgRMS () const
         {
             if (rmsHistory.size() > 0)
-                return std::sqrt (std::accumulate (rmsHistory.begin(), rmsHistory.end(), 0.0) / rmsHistory.size());
+                return std::sqrt (std::accumulate (rmsHistory.begin(), rmsHistory.end(), 0.0f) / rmsHistory.size());
 
             return std::sqrt (rmsSum);
         }
 
-        void setLevels (const juce::int64 time, const float newMax, const float newRms, const juce::int64 holdMSecs)
+        void setLevels (const juce::int64 time, const float newMax, const float newRms, const juce::int64 _holdMSecs)
         {
             if (newMax > 1.0 || newRms > 1.0)
                 clip = true;
@@ -116,7 +116,7 @@ private:
             if (newMax >= max)
             {
                 max = std::min (1.0f, newMax);
-                hold = time + holdMSecs;
+                hold = time + _holdMSecs;
             }
             else if (time > hold)
             {

--- a/ff_meters_LevelMeterSource.h
+++ b/ff_meters_LevelMeterSource.h
@@ -107,7 +107,7 @@ private:
             return (float) std::sqrt (rmsSum);
         }
 
-        void setLevels (const juce::int64 time, const float newMax, const float newRms, const juce::int64 _holdMSecs)
+        void setLevels (const juce::int64 time, const float newMax, const float newRms, const juce::int64 newHoldMSecs)
         {
             if (newMax > 1.0 || newRms > 1.0)
                 clip = true;
@@ -116,7 +116,7 @@ private:
             if (newMax >= max)
             {
                 max = std::min (1.0f, newMax);
-                hold = time + _holdMSecs;
+                hold = time + newHoldMSecs;
             }
             else if (time > hold)
             {

--- a/ff_meters_LookAndFeel.h
+++ b/ff_meters_LookAndFeel.h
@@ -72,7 +72,7 @@ public:
         setupDefaultStereoFieldColours();
     }
 
-    virtual ~LevelMeterLookAndFeel() {}
+    virtual ~LevelMeterLookAndFeel() override {}
 
     // do this include inside the class to get the default implementation instead of copying it there
     #include "ff_meters_LookAndFeelMethods.h"

--- a/ff_meters_LookAndFeelMethods.h
+++ b/ff_meters_LookAndFeelMethods.h
@@ -73,7 +73,7 @@ juce::Rectangle<float> getMeterInnerBounds (const juce::Rectangle<float> bounds,
                                             const FFAU::LevelMeter::MeterFlags meterType) const override
 {
     if (meterType & FFAU::LevelMeter::HasBorder) {
-        const float corner = std::min (bounds.getWidth(), bounds.getHeight()) * 0.01;
+        const float corner = std::min (bounds.getWidth(), bounds.getHeight()) * 0.01f;
         return bounds.reduced (3 + corner);
     }
     return bounds;
@@ -378,7 +378,6 @@ void drawMeterBars (juce::Graphics& g,
             }
         }
         else {
-            const int numChannels = source->getNumChannels();
             const int numDrawnChannels = fixedNumChannels < 0 ? numChannels : fixedNumChannels;
             for (int channel=0; channel < numChannels; ++channel) {
                 drawMeterChannel (g, meterType,
@@ -607,7 +606,7 @@ void drawMeterReduction (juce::Graphics& g,
 }
 
 void drawMeterBarBackground (juce::Graphics& g,
-                             const FFAU::LevelMeter::MeterFlags meterType,
+                             [[maybe_unused]] const FFAU::LevelMeter::MeterFlags meterType,
                              const juce::Rectangle<float> bounds) override
 {
     g.setColour (findColour (FFAU::LevelMeter::lmMeterBackgroundColour));
@@ -686,7 +685,7 @@ void drawTickMarks (juce::Graphics& g,
 }
 
 void drawClipIndicator (juce::Graphics& g,
-                        const FFAU::LevelMeter::MeterFlags meterType,
+                        [[maybe_unused]] const FFAU::LevelMeter::MeterFlags meterType,
                         const juce::Rectangle<float> bounds,
                         const bool hasClipped) override
 {
@@ -697,7 +696,7 @@ void drawClipIndicator (juce::Graphics& g,
 }
 
 void drawClipIndicatorBackground (juce::Graphics& g,
-                                  const FFAU::LevelMeter::MeterFlags meterType,
+                                  [[maybe_unused]] const FFAU::LevelMeter::MeterFlags meterType,
                                   const juce::Rectangle<float> bounds) override
 {
     g.setColour (findColour (FFAU::LevelMeter::lmMeterBackgroundColour));
@@ -707,7 +706,7 @@ void drawClipIndicatorBackground (juce::Graphics& g,
 }
 
 void drawMaxNumber (juce::Graphics& g,
-                    const FFAU::LevelMeter::MeterFlags meterType,
+                    [[maybe_unused]] const FFAU::LevelMeter::MeterFlags meterType,
                     const juce::Rectangle<float> bounds,
                     const float maxGain) override
 {
@@ -724,7 +723,7 @@ void drawMaxNumber (juce::Graphics& g,
 }
 
 void drawMaxNumberBackground (juce::Graphics& g,
-                              const FFAU::LevelMeter::MeterFlags meterType,
+                              [[maybe_unused]] const FFAU::LevelMeter::MeterFlags meterType,
                               const juce::Rectangle<float> bounds) override
 {
     g.setColour (findColour (FFAU::LevelMeter::lmMeterBackgroundColour));

--- a/ff_meters_LookAndFeelMethods.h
+++ b/ff_meters_LookAndFeelMethods.h
@@ -106,23 +106,23 @@ juce::Rectangle<float> getMeterBarBounds (const juce::Rectangle<float> bounds,
 {
     if (meterType & FFAU::LevelMeter::Minimal) {
         if (meterType & FFAU::LevelMeter::Horizontal) {
-            const float margin = bounds.getHeight() * 0.05;
-            const float h      = bounds.getHeight() - 2.0 * margin;
+            const float margin = bounds.getHeight() * 0.05f;
+            const float h      = bounds.getHeight() - 2.0f * margin;
             const float left   = bounds.getX() + margin;
-            const float right  = bounds.getRight() - (4.0 * margin + h);
+            const float right  = bounds.getRight() - (4.0f * margin + h);
             return juce::Rectangle<float>(bounds.getX() + margin,
                                           bounds.getY() + margin,
                                           right - left,
                                           h);
         }
         else {
-            const float margin = bounds.getWidth() * 0.05;
-            const float top    = bounds.getY() + 2.0 * margin + bounds.getWidth() * 0.5;
+            const float margin = bounds.getWidth() * 0.05f;
+            const float top    = bounds.getY() + 2.0f * margin + bounds.getWidth() * 0.5f;
             const float bottom = (meterType & FFAU::LevelMeter::MaxNumber) ?
-                                  bounds.getBottom() - (3.0f * margin + (bounds.getWidth() - margin * 2.0))
+                                  bounds.getBottom() - (3.0f * margin + (bounds.getWidth() - margin * 2.0f))
                                   : bounds.getBottom() - margin;
             return juce::Rectangle<float>(bounds.getX() + margin, top,
-                                          bounds.getWidth() - margin * 2.0, bottom - top);
+                                          bounds.getWidth() - margin * 2.0f, bottom - top);
         }
     }
     else if (meterType & FFAU::LevelMeter::Vintage) {
@@ -130,20 +130,20 @@ juce::Rectangle<float> getMeterBarBounds (const juce::Rectangle<float> bounds,
     }
     else {
         if (meterType & FFAU::LevelMeter::Horizontal) {
-            const float margin = bounds.getHeight() * 0.05;
-            const float h      = bounds.getHeight() * 0.5 - 2.0 * margin;
-            const float left   = 60.0 + 3.0 * margin;
-            const float right  = bounds.getRight() - (4.0 * margin + h * 0.5);
+            const float margin = bounds.getHeight() * 0.05f;
+            const float h      = bounds.getHeight() * 0.5f - 2.0f * margin;
+            const float left   = 60.0f + 3.0f * margin;
+            const float right  = bounds.getRight() - (4.0f * margin + h * 0.5f);
             return juce::Rectangle<float>(bounds.getX() + left,
                                           bounds.getY() + margin,
                                           right - left,
                                           h);
         }
         else {
-            const float margin = bounds.getWidth() * 0.05;
-            const float w      = bounds.getWidth() * 0.45;
-            const float top    = bounds.getY() + 2.0 * margin + w * 0.5;
-            const float bottom = bounds.getBottom() - (2.0 * margin + 25.0);
+            const float margin = bounds.getWidth() * 0.05f;
+            const float w      = bounds.getWidth() * 0.45f;
+            const float top    = bounds.getY() + 2.0f * margin + w * 0.5f;
+            const float bottom = bounds.getBottom() - (2.0f * margin + 25.0f);
             return juce::Rectangle<float>(bounds.getX() + margin, top, w, bottom - top);
         }
     }
@@ -167,20 +167,20 @@ juce::Rectangle<float> getMeterTickmarksBounds (const juce::Rectangle<float> bou
         return bounds;
     } else {
         if (meterType & FFAU::LevelMeter::Horizontal) {
-            const float margin = bounds.getHeight() * 0.05;
-            const float h      = bounds.getHeight() * 0.5 - 2.0 * margin;
-            const float left   = 60.0 + 3.0 * margin;
-            const float right  = bounds.getRight() - (4.0 * margin + h * 0.5);
+            const float margin = bounds.getHeight() * 0.05f;
+            const float h      = bounds.getHeight() * 0.5f - 2.0f * margin;
+            const float left   = 60.0f + 3.0f * margin;
+            const float right  = bounds.getRight() - (4.0f * margin + h * 0.5f);
             return juce::Rectangle<float>(bounds.getX() + left,
                                           bounds.getCentreY() + margin,
                                           right - left,
                                           h);
         }
         else {
-            const float margin = bounds.getWidth() * 0.05;
-            const float w      = bounds.getWidth() * 0.45;
-            const float top    = bounds.getY() + 2.0 * margin + w * 0.5 + 2.0;
-            const float bottom = bounds.getBottom() - (2.0 * margin + 25.0 + 2.0);
+            const float margin = bounds.getWidth() * 0.05f;
+            const float w      = bounds.getWidth() * 0.45f;
+            const float top    = bounds.getY() + 2.0f * margin + w * 0.5f + 2.0f;
+            const float bottom = bounds.getBottom() - (2.0f * margin + 25.0f + 2.0f);
             return juce::Rectangle<float>(bounds.getCentreX(), top, w, bottom - top);
         }
     }
@@ -194,20 +194,20 @@ juce::Rectangle<float> getMeterClipIndicatorBounds (const juce::Rectangle<float>
 {
     if (meterType & FFAU::LevelMeter::Minimal) {
         if (meterType & FFAU::LevelMeter::Horizontal) {
-            const float margin = bounds.getHeight() * 0.05;
-            const float h      = bounds.getHeight() - 2.0 * margin;
+            const float margin = bounds.getHeight() * 0.05f;
+            const float h      = bounds.getHeight() - 2.0f * margin;
             return juce::Rectangle<float>(bounds.getRight() - (margin + h),
                                           bounds.getY() + margin,
                                           h,
                                           h);
         }
         else {
-            const float margin = bounds.getWidth() * 0.05;
-            const float w      = bounds.getWidth() - margin * 2.0;
+            const float margin = bounds.getWidth() * 0.05f;
+            const float w      = bounds.getWidth() - margin * 2.0f;
             return juce::Rectangle<float>(bounds.getX() + margin,
                                           bounds.getY() + margin,
                                           w,
-                                          w * 0.5);
+                                          w * 0.5f);
         }
     }
     else if (meterType & FFAU::LevelMeter::Vintage) {
@@ -215,20 +215,20 @@ juce::Rectangle<float> getMeterClipIndicatorBounds (const juce::Rectangle<float>
     }
     else {
         if (meterType & FFAU::LevelMeter::Horizontal) {
-            const float margin = bounds.getHeight() * 0.05;
-            const float h      = bounds.getHeight() * 0.5 - 2.0 * margin;
-            return juce::Rectangle<float>(bounds.getRight() - (margin + h * 0.5),
+            const float margin = bounds.getHeight() * 0.05f;
+            const float h      = bounds.getHeight() * 0.5f - 2.0f * margin;
+            return juce::Rectangle<float>(bounds.getRight() - (margin + h * 0.5f),
                                           bounds.getY() + margin,
-                                          h * 0.5,
+                                          h * 0.5f,
                                           h);
         }
         else {
-            const float margin = bounds.getWidth() * 0.05;
-            const float w      = bounds.getWidth() * 0.45;
+            const float margin = bounds.getWidth() * 0.05f;
+            const float w      = bounds.getWidth() * 0.45f;
             return juce::Rectangle<float>(bounds.getX() + margin,
                                           bounds.getY() + margin,
                                           w,
-                                          w * 0.5);
+                                          w * 0.5f);
         }
     }
     return juce::Rectangle<float> ();
@@ -242,15 +242,15 @@ juce::Rectangle<float> getMeterMaxNumberBounds (const juce::Rectangle<float> bou
     if (meterType & FFAU::LevelMeter::Minimal) {
         if (meterType & FFAU::LevelMeter::MaxNumber) {
             if (meterType & FFAU::LevelMeter::Horizontal) {
-                const float margin = bounds.getHeight() * 0.05;
-                const float h      = bounds.getHeight() - 2.0 * margin;
+                const float margin = bounds.getHeight() * 0.05f;
+                const float h      = bounds.getHeight() - 2.0f * margin;
                 return juce::Rectangle<float>(bounds.getRight() - (margin + h),
                                               bounds.getY() + margin,
                                               h, h);
             }
             else {
-                const float margin = bounds.getWidth() * 0.05;
-                const float w      = bounds.getWidth() - margin * 2.0;
+                const float margin = bounds.getWidth() * 0.05f;
+                const float w      = bounds.getWidth() - margin * 2.0f;
                 const float h      = w * 0.6f;
                 return juce::Rectangle<float>(bounds.getX() + margin,
                                               bounds.getBottom() - (margin + h),
@@ -266,14 +266,14 @@ juce::Rectangle<float> getMeterMaxNumberBounds (const juce::Rectangle<float> bou
     }
     else {
         if (meterType & FFAU::LevelMeter::Horizontal) {
-            const float margin = bounds.getHeight() * 0.05;
+            const float margin = bounds.getHeight() * 0.05f;
             return juce::Rectangle<float>(bounds.getX() + margin,
                                           bounds.getCentreY() + margin,
                                           60,
-                                          bounds.getHeight() * 0.5 - margin * 2.0);
+                                          bounds.getHeight() * 0.5f - margin * 2.0f);
         }
         else {
-            const float margin = bounds.getWidth() * 0.05;
+            const float margin = bounds.getWidth() * 0.05f;
             return juce::Rectangle<float>(bounds.getX() + margin,
                                           bounds.getBottom() - (margin + 25),
                                           bounds.getWidth() - 2 * margin,
@@ -288,7 +288,7 @@ juce::Rectangle<float> drawBackground (juce::Graphics& g,
 {
     g.setColour (findColour (FFAU::LevelMeter::lmBackgroundColour));
     if (meterType & FFAU::LevelMeter::HasBorder) {
-        const float corner = std::min (bounds.getWidth(), bounds.getHeight()) * 0.01;
+        const float corner = std::min (bounds.getWidth(), bounds.getHeight()) * 0.01f;
         g.fillRoundedRectangle (bounds, corner);
         g.setColour (findColour (FFAU::LevelMeter::lmOutlineColour));
         g.drawRoundedRectangle (bounds.reduced (3), corner, 2);
@@ -556,8 +556,9 @@ void drawMeterBar (juce::Graphics& g,
                 g.setColour (findColour ((peakDb > -0.3f) ? FFAU::LevelMeter::lmMeterMaxOverColour :
                                          ((peakDb > -5.0) ? FFAU::LevelMeter::lmMeterMaxWarnColour :
                                           FFAU::LevelMeter::lmMeterMaxNormalColour)));
-                g.drawVerticalLine (floored.getRight() - juce::jmax (peakDb * floored.getWidth() / infinity, 0.0f),
-                                    floored.getY(), floored.getBottom());
+                g.drawVerticalLine (juce::roundToInt(floored.getRight() - juce::jmax (peakDb * floored.getWidth() / infinity, 0.0f)),
+                                    floored.getY(),
+                                    floored.getBottom());
             }
         }
         else {
@@ -577,8 +578,9 @@ void drawMeterBar (juce::Graphics& g,
                 g.setColour (findColour ((peakDb > -0.3f) ? FFAU::LevelMeter::lmMeterMaxOverColour :
                                          ((peakDb > -5.0) ? FFAU::LevelMeter::lmMeterMaxWarnColour :
                                           FFAU::LevelMeter::lmMeterMaxNormalColour)));
-                g.drawHorizontalLine (floored.getY() + juce::jmax (peakDb * floored.getHeight() / infinity, 0.0f),
-                                      floored.getX(), floored.getRight());
+                g.drawHorizontalLine (juce::roundToInt(floored.getY() + juce::jmax (peakDb * floored.getHeight() / infinity, 0.0f)),
+                                      floored.getX(),
+                                      floored.getRight());
             }
         }
     }
@@ -626,14 +628,14 @@ void drawTickMarks (juce::Graphics& g,
     if (meterType & FFAU::LevelMeter::Minimal) {
         if (meterType & FFAU::LevelMeter::Horizontal) {
             for (int i=0; i<11; ++i)
-                g.drawVerticalLine (bounds.getX() + i * 0.1f * bounds.getWidth(),
+                g.drawVerticalLine (juce::roundToInt(bounds.getX() + i * 0.1f * bounds.getWidth()),
                                     bounds.getY() + 4,
                                     bounds.getBottom() - 4);
         }
         else {
-            const float h = (bounds.getHeight() - 2.0) * 0.1;
+            const float h = (bounds.getHeight() - 2.0f) * 0.1f;
             for (int i=0; i<11; ++i) {
-                g.drawHorizontalLine (bounds.getY() + i * h + 1,
+                g.drawHorizontalLine (juce::roundToInt(bounds.getY() + i * h + 1),
                                       bounds.getX() + 4,
                                       bounds.getRight());
             }
@@ -642,8 +644,10 @@ void drawTickMarks (juce::Graphics& g,
                 g.setFont (h * 0.5f);
                 for (int i=0; i<10; ++i) {
                     g.drawFittedText (juce::String (i * 0.1 * infinity),
-                                      bounds.getX(), bounds.getY() + i * h + 2, bounds.getWidth(),
-                                      h * 0.6,
+                                      juce::roundToInt(bounds.getX()),
+                                      juce::roundToInt(bounds.getY() + (float) i * h + 2.0f),
+                                      juce::roundToInt(bounds.getWidth()),
+                                      juce::roundToInt((float) h * 0.6f),
                                       juce::Justification::centredTop, 1);
                 }
             }
@@ -655,29 +659,32 @@ void drawTickMarks (juce::Graphics& g,
     else {
         if (meterType & FFAU::LevelMeter::Horizontal) {
             for (int i=0; i<11; ++i)
-                g.drawVerticalLine (bounds.getX() + i * 0.1f * bounds.getWidth(),
+                g.drawVerticalLine (juce::roundToInt(bounds.getX() + i * 0.1f * bounds.getWidth()),
                                     bounds.getY() + 4,
                                     bounds.getBottom() - 4);
         }
         else {
-            const float h = (bounds.getHeight() - 2.0) * 0.05;
+            const float h = (bounds.getHeight() - 2.0f) * 0.05f;
             g.setFont (h * 0.8f);
             for (int i=0; i<21; ++i) {
                 const float y = bounds.getY() + i * h;
                 if (i % 2 == 0) {
-                    g.drawHorizontalLine (y + 1,
+                    g.drawHorizontalLine (juce::roundToInt(y + 1),
                                           bounds.getX() + 4,
                                           bounds.getRight());
                     if (i < 20) {
-                        g.drawFittedText (juce::String (i * 0.05 * infinity),
-                                          bounds.getX(), y + 4, bounds.getWidth(), h * 0.6,
+                        g.drawFittedText (juce::String (i * 0.05f * infinity),
+                                          juce::roundToInt(bounds.getX()),
+                                          juce::roundToInt(y + 4),
+                                          juce::roundToInt(bounds.getWidth()),
+                                          juce::roundToInt(h * 0.6f),
                                           juce::Justification::topRight, 1);
                     }
                 }
                 else {
-                    g.drawHorizontalLine (y + 2,
-                                          bounds.getX() + 4,
-                                          bounds.getCentreX());
+                  g.drawHorizontalLine (juce::roundToInt(y + 2),
+                                        bounds.getX() + 4,
+                                        bounds.getCentreX());
                 }
             }
         }

--- a/ff_meters_OutlineBuffer.h
+++ b/ff_meters_OutlineBuffer.h
@@ -96,8 +96,8 @@ namespace FFAU
              */
             void setSize (const int numBlocks)
             {
-                minBuffer.resize (numBlocks, 0.0f);
-                maxBuffer.resize (numBlocks, 0.0f);
+                minBuffer.resize ((size_t) numBlocks, 0.0f);
+                maxBuffer.resize ((size_t) numBlocks, 0.0f);
                 writePointer = writePointer % numBlocks;
             }
 
@@ -110,23 +110,23 @@ namespace FFAU
                     int leftover = numSamples - samples;
                     if (fraction > 0) {
                         minMax = juce::FloatVectorOperations::findMinAndMax (input, samplesPerBlock - fraction);
-                        maxBuffer [writePointer] = std::max (maxBuffer [writePointer], minMax.getEnd());
-                        minBuffer [writePointer] = std::min (minBuffer [writePointer], minMax.getStart());
+                        maxBuffer [(size_t) writePointer] = std::max (maxBuffer [(size_t) writePointer], minMax.getEnd());
+                        minBuffer [(size_t) writePointer] = std::min (minBuffer [(size_t) writePointer], minMax.getStart());
                         samples += samplesPerBlock - fraction;
                         fraction = 0;
-                        writePointer = (writePointer + 1) % maxBuffer.size();
+                        writePointer = (writePointer + 1) % (int) maxBuffer.size();
                     }
                     else if (leftover > samplesPerBlock) {
                         minMax = juce::FloatVectorOperations::findMinAndMax (input + samples, samplesPerBlock);
-                        maxBuffer [writePointer] = minMax.getEnd();
-                        minBuffer [writePointer] = minMax.getStart();
+                        maxBuffer [(size_t) writePointer] = minMax.getEnd();
+                        minBuffer [(size_t) writePointer] = minMax.getStart();
                         samples += samplesPerBlock;
-                        writePointer = (writePointer + 1) % maxBuffer.size();
+                        writePointer = (writePointer + 1) % (int) maxBuffer.size();
                     }
                     else {
                         minMax = juce::FloatVectorOperations::findMinAndMax (input + samples, leftover);
-                        maxBuffer [writePointer] = minMax.getEnd();
-                        minBuffer [writePointer] = minMax.getStart();
+                        maxBuffer [(size_t) writePointer] = minMax.getEnd();
+                        minBuffer [(size_t) writePointer] = minMax.getStart();
                         samples += samplesPerBlock - fraction;
                         fraction = leftover;
                     }
@@ -144,7 +144,7 @@ namespace FFAU
                 const float dy = bounds.getHeight() * 0.35f;
                 const float my = bounds.getCentreY();
                 float  x  = bounds.getX();
-                size_t s  = oldest;
+                size_t s  = (size_t) oldest;
 
                 outline.startNewSubPath (x, my);
                 for (int i=0; i<numSamples; ++i) {
@@ -161,7 +161,7 @@ namespace FFAU
                     if (s > 1)
                         s -= 1;
                     else
-                        s = bufferSize - 1;
+                        s = (size_t) bufferSize - 1;
                 }
             }
         };
@@ -183,7 +183,7 @@ namespace FFAU
          */
         void setSize (const int numChannels, const int numBlocks)
         {
-            channelDatas.resize (numChannels);
+            channelDatas.resize ((size_t) numChannels);
             for (auto& data : channelDatas) {
                 data.setSize (numBlocks);
                 data.setSamplesPerBlock (samplesPerBlock);
@@ -207,7 +207,7 @@ namespace FFAU
         {
             for (int i=0; i < buffer.getNumChannels(); ++i) {
                 if (i < int (channelDatas.size())) {
-                    channelDatas [i].pushChannelData (buffer.getReadPointer (i), numSamples);
+                    channelDatas [(size_t) i].pushChannelData (buffer.getReadPointer (i), numSamples);
                 }
             }
         }
@@ -223,7 +223,7 @@ namespace FFAU
         void getChannelOutline (juce::Path& path, const juce::Rectangle<float> bounds, const int channel, const int numSamples) const
         {
             if (channel < int (channelDatas.size()))
-                return channelDatas [channel].getChannelOutline (path, bounds, numSamples);
+                return channelDatas [(size_t) channel].getChannelOutline (path, bounds, numSamples);
         }
 
         /**

--- a/ff_meters_SoundFieldLookAndFeelMethods.h
+++ b/ff_meters_SoundFieldLookAndFeelMethods.h
@@ -58,7 +58,7 @@ void drawGonioBackground (juce::Graphics& g, const juce::Rectangle<float> bounds
     g.fillAll (colour);
     colour = findColour (StereoFieldComponent::borderColour);
     g.setColour (colour);
-    g.drawRoundedRectangle (bounds.reduced (margin * 0.5), margin * 0.5, border);
+    g.drawRoundedRectangle (bounds.reduced (margin * 0.5f), margin * 0.5f, border);
 
     colour = findColour (StereoFieldComponent::outlineColour);
     g.setColour (colour);
@@ -83,7 +83,7 @@ void drawGonioMeter (juce::Graphics& g,
 
 void drawStereoFieldBackground (juce::Graphics& g, const juce::Rectangle<float> bounds, float margin, float border) override
 {
-    g.drawRoundedRectangle (bounds.reduced (margin * 0.5), margin * 0.5, border);
+    g.drawRoundedRectangle (bounds.reduced (margin * 0.5f), margin * 0.5f, border);
     auto graph = bounds.reduced (margin);
     juce::Path background;
     background.addRectangle (graph);
@@ -104,10 +104,11 @@ void drawStereoFieldBackground (juce::Graphics& g, const juce::Rectangle<float> 
 
 }
 
-void drawStereoField (juce::Graphics& g,
-                      const juce::Rectangle<float> bounds,
-                      const StereoFieldBuffer<float>&,
-                      const int leftIdx = 0, const int rightIdx = 1) override
+void drawStereoField ([[maybe_unused]] juce::Graphics& g,
+                      [[maybe_unused]] const juce::Rectangle<float> bounds,
+                      [[maybe_unused]] const StereoFieldBuffer<float>&,
+                      [[maybe_unused]] const int leftIdx = 0,
+                      [[maybe_unused]] const int rightIdx = 1) override
 {
 
 }

--- a/ff_meters_StereoFieldBuffer.h
+++ b/ff_meters_StereoFieldBuffer.h
@@ -77,8 +77,8 @@ namespace FFAU
 
         inline juce::Point<FloatType> computePosition (const juce::Rectangle<FloatType>& b, const FloatType left, const FloatType right) const
         {
-            return juce::Point<FloatType> (b.getCentreX() + 0.5 * b.getWidth() * (right - left),
-                                           b.getCentreY() + 0.5 * b.getHeight() * (left + right));
+            return juce::Point<FloatType> (b.getCentreX() + 0.5f * b.getWidth() * (right - left),
+                                           b.getCentreY() + 0.5f * b.getHeight() * (left + right));
         }
 
     public:


### PR DESCRIPTION
thanks so much for this module!

i've got clang warnings enabled in xcode and > 100 of them popped up when i pulled in this module. most of the fixes are one of:

1. conversion to `size_t` for vector operations
2. moving numeric literals to `.f`
3. using `juce::roundToInt` instead of allowing floats to be implicitly rounded. 
4. marking unused parameters with the `[[maybe_unused]]` attribute

